### PR TITLE
fix: Retrieve AlbumCount in GetAlbumArtists

### DIFF
--- a/browsing.go
+++ b/browsing.go
@@ -43,6 +43,7 @@ func (c *Client) GetAlbumArtists(opts QueryOpts) ([]*Artist, error) {
 	params.setFilter(mediaTypeArtist, opts.Filter)
 	params.setPaging(opts.Paging)
 	params.setSorting(opts.Sort)
+	params.setIncludeTypes(mediaTypeAlbum)
 	params.setIncludeFields(artistIncludeFields...)
 	resp, err := c.get("/Artists/AlbumArtists", params)
 	if err != nil {

--- a/models.go
+++ b/models.go
@@ -66,7 +66,7 @@ type Artist struct {
 	ID           string   `json:"Id"`
 	RunTimeTicks int64    `json:"RunTimeTicks"`
 	Type         string   `json:"Type"`
-	AlbumCount   int      `json:"ChildCount"`
+	AlbumCount   int      `json:"AlbumCount"`
 	UserData     UserData `json:"UserData"`
 	ImageTags    Images   `json:"ImageTags"`
 }


### PR DESCRIPTION
The `GetAlbumArtists` function was not returning the children counters. Based on the Jellyfin implementation, it seems we need to send at least one value for `IncludeItemTypes` [1]

Also, Jellyfin differentiates between counters, so we can use `AlbumCount`, in case that one gets a different value than `ChildCount`.

[1] https://github.com/jellyfin/jellyfin/blob/a3994556cd4240e3d7309c089645fa76cbac8abb/Jellyfin.Api/Controllers/ArtistsController.cs#L435