### PR TITLE
fix: include playlists with "Unknown"  media type to support .m3u files

### DIFF
--- a/browsing.go
+++ b/browsing.go
@@ -183,10 +183,12 @@ func (c *Client) GetPlaylists() ([]*Playlist, error) {
 		return nil, fmt.Errorf("parse playlists: %v", err)
 	}
 
-	// filter to MediaType == "Audio"
+	// filter MediaTypes:
+	//   - "Audio"   for music playlists created by Jellyfin UI
+	//   - "Unknown" for .m3u files discovered in music libraries
 	musicPlaylists := make([]*Playlist, 0)
 	for _, pl := range dto.Playlists {
-		if pl.MediaType == string(mediaTypeAudio) {
+		if pl.MediaType == string(mediaTypeAudio) || pl.MediaType == string(mediaTypeUnknown) {
 			musicPlaylists = append(musicPlaylists, pl)
 		}
 	}

--- a/internalconsts.go
+++ b/internalconsts.go
@@ -6,6 +6,7 @@ const (
 	mediaTypeAlbum        mediaItemType = "MusicAlbum"
 	mediaTypeArtist       mediaItemType = "MusicArtist"
 	mediaTypeAudio        mediaItemType = "Audio"
+	mediaTypeUnknown      mediaItemType = "Unknown"
 	mediaTypePlaylist     mediaItemType = "Playlist"
 	folderTypePlaylists   mediaItemType = "PlaylistsFolder"
 	folderTypeCollections mediaItemType = "CollectionFolder"


### PR DESCRIPTION
For https://github.com/dweymouth/supersonic/issues/414.

Jellyfin returns playlists that have been scanned from .m3u files as "Unknown" but Supersonic filters out any non-Audio playlist out.

Testing has been limited to:

- Jellyfin 10.10.7 and Supersonic 0.18
- running Supersonic, seeing .m3u playlists are now loaded and confirming the music plays
- confirm that nothing strange happens if .m3u files contain videos
- I note that Jellyfin is only loading music into .m3u playlists when I put them at the root of the music library. If there are in a sub-folder then they appear as empty in the web-interface and other clients

---

:warning: I am not a golang programmer... don't trust a single character!